### PR TITLE
Add "global" feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ rand = "0.3"
 debug-assertions = true
 
 [features]
+default = ["global"]
+global = []
 debug = []
 allocator-api = []

--- a/src/dlmalloc.rs
+++ b/src/dlmalloc.rs
@@ -26,6 +26,8 @@ pub struct Dlmalloc {
     release_checks: usize,
 }
 
+unsafe impl Send for Dlmalloc {}
+
 pub const DLMALLOC_INIT: Dlmalloc = Dlmalloc {
     smallmap: 0,
     treemap: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@ use core::alloc::{Alloc, Layout, AllocErr};
 use core::cmp;
 use core::ptr;
 
+#[cfg(feature = "global")]
 pub use self::global::GlobalDlmalloc;
 
+#[cfg(feature = "global")]
 mod global;
 mod dlmalloc;
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -44,14 +44,17 @@ pub fn can_release_part(_flags: u32) -> bool {
     true
 }
 
+#[cfg(feature = "global")]
 static mut LOCK: libc::pthread_mutex_t = libc::PTHREAD_MUTEX_INITIALIZER;
 
+#[cfg(feature = "global")]
 pub fn acquire_global_lock() {
     unsafe {
         assert_eq!(libc::pthread_mutex_lock(&mut LOCK), 0)
     }
 }
 
+#[cfg(feature = "global")]
 pub fn release_global_lock() {
     unsafe {
         assert_eq!(libc::pthread_mutex_unlock(&mut LOCK), 0)

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -34,14 +34,17 @@ pub fn can_release_part(_flags: u32) -> bool {
     true
 }
 
+#[cfg(feature = "global")]
 static mut LOCK: libc::pthread_mutex_t = libc::PTHREAD_MUTEX_INITIALIZER;
 
+#[cfg(feature = "global")]
 pub fn acquire_global_lock() {
     unsafe {
         assert_eq!(libc::pthread_mutex_lock(&mut LOCK), 0)
     }
 }
 
+#[cfg(feature = "global")]
 pub fn release_global_lock() {
     unsafe {
         assert_eq!(libc::pthread_mutex_unlock(&mut LOCK), 0)

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -34,10 +34,12 @@ pub fn can_release_part(_flags: u32) -> bool {
     false
 }
 
+#[cfg(feature = "global")]
 pub fn acquire_global_lock() {
     // single threaded, no need!
 }
 
+#[cfg(feature = "global")]
 pub fn release_global_lock() {
     // single threaded, no need!
 }


### PR DESCRIPTION
This feature-gates `GlobalDlmalloc` and dependent functions. This creates a clean break between the pure Dlmalloc port and bindings to the Rust allocator system.

In the near future I will be filing a follow-up PR that adds a new target for which it isn't possible to implement `acquire_global_lock` in `core`.