### PR TITLE
Fix integer overflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ features = ['global']
 
 [lib]
 doctest = false
-test = false
 
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,10 @@ use core::alloc::{Alloc, Layout, AllocErr};
 use core::cmp;
 use core::ptr;
 
-#[cfg(feature = "global")]
+#[cfg(all(feature = "global", not(test)))]
 pub use self::global::GlobalDlmalloc;
 
-#[cfg(feature = "global")]
+#[cfg(all(feature = "global", not(test)))]
 mod global;
 mod dlmalloc;
 


### PR DESCRIPTION
Fix two integer overflows.

1. In `left_bits`, use wrapping arithmetic, as used in the C version. I checked this gives the correct result for `0x8000_0000`.

2. In `align_up`, there is still a possible overflow if `(a + alignment -1) > usize::MAX`. I fixed a case where this could happen in `sys_alloc`. I did a cursory audit of all uses of `align_up` (transitively through `pad_request`, `mmap_align`, `request2size`) and I believe there is now always an appropriate check before calling `align_up`.