### PR TITLE
Use llvm_asm! instead of asm!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! testing this crate.
 
 #![cfg_attr(feature = "allocator-api", feature(allocator_api))]
-#![cfg_attr(target_env = "sgx", feature(asm))]
+#![cfg_attr(target_env = "sgx", feature(llvm_asm))]
 #![cfg_attr(not(feature = "allocator-api"), allow(dead_code))]
 #![no_std]
 #![deny(missing_docs)]

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -13,7 +13,7 @@ unsafe fn rel_ptr_mut<T>(offset: u64) -> *mut T {
 #[inline(always)]
 fn image_base() -> u64 {
     let base;
-    unsafe { asm!("lea IMAGE_BASE(%rip),$0":"=r"(base)) };
+    unsafe { llvm_asm!("lea IMAGE_BASE(%rip),$0":"=r"(base)) };
     base
 }
 


### PR DESCRIPTION
The `asm!` syntax is changing: https://github.com/rust-lang/rust/pull/69171