### PR TITLE
Fixing `allocator-api` feature

### DIFF
--- a/src/global.rs
+++ b/src/global.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "allocator-api")]
-use core::alloc::{Alloc, AllocErr};
+use core::alloc::{AllocErr, AllocRef};
 use core::alloc::{GlobalAlloc, Layout};
 use core::ops::{Deref, DerefMut};
 #[cfg(feature = "allocator-api")]
@@ -36,10 +36,10 @@ unsafe impl GlobalAlloc for GlobalDlmalloc {
 }
 
 #[cfg(feature = "allocator-api")]
-unsafe impl Alloc for GlobalDlmalloc {
+unsafe impl AllocRef for GlobalDlmalloc {
     #[inline]
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        get().alloc(layout)
+    fn alloc(&mut self, layout: Layout) -> Result<NonNull<[u8]>, AllocErr> {
+        unsafe { get().alloc(layout) }
     }
 
     #[inline]
@@ -48,18 +48,8 @@ unsafe impl Alloc for GlobalDlmalloc {
     }
 
     #[inline]
-    unsafe fn realloc(
-        &mut self,
-        ptr: NonNull<u8>,
-        layout: Layout,
-        new_size: usize,
-    ) -> Result<NonNull<u8>, AllocErr> {
-        Alloc::realloc(&mut *get(), ptr, layout, new_size)
-    }
-
-    #[inline]
-    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        get().alloc_zeroed(layout)
+    fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<[u8]>, AllocErr> {
+        unsafe { get().alloc_zeroed(layout) }
     }
 }
 


### PR DESCRIPTION
The `allocator-api` feature is broken on master. This PR fixes this.