### PR TITLE
Compile fixes for external platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,3 +38,12 @@ jobs:
       run: rustup update stable && rustup default stable && rustup target add wasm32-unknown-unknown
     - run: cargo build --target wasm32-unknown-unknown
     - run: cargo build --target wasm32-unknown-unknown --release
+
+  external-platform:
+    name: external-platform
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable && rustup target add x86_64-fortanix-unknown-sgx
+    - run: cargo build --target x86_64-fortanix-unknown-sgx

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -6,29 +6,29 @@ pub struct System {
 }
 
 impl System {
-    const fn new() -> System {
+    pub const fn new() -> System {
         System { _priv: () }
     }
 }
 
 unsafe impl Allocator for System {
-    fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
+    fn alloc(&self, _size: usize) -> (*mut u8, usize, u32) {
         (ptr::null_mut(), 0, 0)
     }
 
-    fn remap(&self, ptr: *mut u8, oldsize: usize, newsize: usize, can_move: bool) -> *mut u8 {
+    fn remap(&self, _ptr: *mut u8, _oldsize: usize, _newsize: usize, _can_move: bool) -> *mut u8 {
         ptr::null_mut()
     }
 
-    fn free_part(&self, ptr: *mut u8, oldsize: usize, newsize: usize) -> bool {
+    fn free_part(&self, _ptr: *mut u8, _oldsize: usize, _newsize: usize) -> bool {
         false
     }
 
-    fn free(&self, ptr: *mut u8, size: usize) -> bool {
+    fn free(&self, _ptr: *mut u8, _size: usize) -> bool {
         false
     }
 
-    fn can_release_part(&self, flags: u32) -> bool {
+    fn can_release_part(&self, _flags: u32) -> bool {
         false
     }
 


### PR DESCRIPTION
Sorry @alexcrichton, there are compile time errors when building for an "external platform" (.i.e., not Linux, MacOS, Wasm). I forgot that CI doesn't test for this. What's your take on this? Is it worth while to add a (compile) test?

cc: @jethrogb
