### PR TITLE
allow locking the global allocator

### DIFF
--- a/src/global.rs
+++ b/src/global.rs
@@ -9,6 +9,27 @@ use Dlmalloc;
 /// implements the `GlobalAlloc` trait in the standard library.
 pub struct GlobalDlmalloc;
 
+impl GlobalDlmalloc {
+    /// Lock the global allocator.
+    ///
+    /// Any attempt to allocate using this allocator will block the calling thread,
+    /// until the allocator is unlocked.
+    #[inline]
+    pub fn lock(&self) {
+        ::sys::acquire_global_lock()
+    }
+
+    ///  Unlock the global allocator.
+    ///
+    /// # Safety
+    ///
+    /// This method may only be called if the allocator is currently locked.
+    #[inline]
+    pub unsafe fn unlock(&self) {
+        ::sys::release_global_lock()
+    }
+}
+
 unsafe impl GlobalAlloc for GlobalDlmalloc {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {


### PR DESCRIPTION
when a thread calls `fork(2)`, if an other thread acquires the allocator lock,
the child process would be deadlocked on any attempt to allocate, since only the calling thread persists in the new process.

to allow allocations to work as intended after the fork, the forking thread can lock the allocator before the fork and release the lock afterwards.

this exposes the public API used to do that.