### PR TITLE
make allocations safe in fork

### DIFF
--- a/src/global.rs
+++ b/src/global.rs
@@ -3,6 +3,8 @@ use core::ops::{Deref, DerefMut};
 
 use Dlmalloc;
 
+pub use sys::enable_alloc_after_fork;
+
 /// An instance of a "global allocator" backed by `Dlmalloc`
 ///
 /// This API requires the `global` feature is activated, and this type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use core::ptr;
 use sys::System;
 
 #[cfg(feature = "global")]
-pub use self::global::GlobalDlmalloc;
+pub use self::global::{enable_alloc_after_fork, GlobalDlmalloc};
 
 mod dlmalloc;
 #[cfg(feature = "global")]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -63,34 +63,47 @@ unsafe impl Allocator for System {
 
 #[cfg(feature = "global")]
 pub fn acquire_global_lock() {
-    static mut FORK_PROTECTED: bool = false;
-
-    unsafe {
-        assert_eq!(libc::pthread_mutex_lock(&mut LOCK), 0);
-        if !FORK_PROTECTED {
-            // ensures that if a process forks,
-            // it will acquire the lock before any other thread,
-            // protecting it from deadlock,
-            // when the child is created with only that thread.
-            libc::pthread_atfork(
-                Some(_acquire_global_lock),
-                Some(_release_global_lock),
-                Some(_release_global_lock),
-            );
-            FORK_PROTECTED = true;
-        }
-    }
-
-    unsafe extern "C" fn _acquire_global_lock() {
-        assert_eq!(libc::pthread_mutex_lock(&mut LOCK), 0)
-    }
-
-    unsafe extern "C" fn _release_global_lock() {
-        release_global_lock()
-    }
+    unsafe { assert_eq!(libc::pthread_mutex_lock(&mut LOCK), 0) }
 }
 
 #[cfg(feature = "global")]
 pub fn release_global_lock() {
     unsafe { assert_eq!(libc::pthread_mutex_unlock(&mut LOCK), 0) }
+}
+
+#[cfg(feature = "global")]
+/// allows the allocator to remain unsable in the child process,
+/// after a call to `fork(2)`
+///
+/// #Safety
+///
+/// if used, this function must be called,
+/// before any allocations are made with the global allocator.
+pub unsafe fn enable_alloc_after_fork() {
+    // atfork must only be called once, to avoid a deadlock,
+    // where the handler attempts to acquire the global lock twice
+    static mut FORK_PROTECTED: bool = false;
+
+    unsafe extern "C" fn _acquire_global_lock() {
+        acquire_global_lock()
+    }
+
+    unsafe extern "C" fn _release_global_lock() {
+        release_global_lock()
+    }
+
+    acquire_global_lock();
+    // if a process forks,
+    // it will acquire the lock before any other thread,
+    // protecting it from deadlock,
+    // due to the child being created with only the calling thread.
+    if !FORK_PROTECTED {
+        libc::pthread_atfork(
+            Some(_acquire_global_lock),
+            Some(_release_global_lock),
+            Some(_release_global_lock),
+        );
+        FORK_PROTECTED = true;
+    }
+    release_global_lock();
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -62,3 +62,8 @@ pub fn acquire_global_lock() {
 pub fn release_global_lock() {
     // single threaded, no need!
 }
+
+#[cfg(feature = "global")]
+pub unsafe fn enable_alloc_after_fork() {
+    // single threaded, no need!
+}


### PR DESCRIPTION
when a thread calls `fork(2)`, if an other thread acquires the allocator lock,
the child process would be deadlocked on any attempt to allocate, since only the calling thread persists in the new process.

this feature allows allocations to work as intended after the fork, by locking the global allocator before the fork and release the lock afterwards in the forking thread, using `pthread_atfork`.