### PR TITLE
Add support for wasm64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub unsafe trait Allocator: Send {
 /// lingering memory back to the OS. That may happen eventually though!
 pub struct Dlmalloc<A = System>(dlmalloc::Dlmalloc<A>);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[path = "wasm.rs"]
 mod sys;
 
@@ -80,7 +80,7 @@ mod sys;
 #[path = "unix.rs"]
 mod sys;
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_arch = "wasm32")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_family = "wasm")))]
 #[path = "dummy.rs"]
 mod sys;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,7 @@
-use core::arch::wasm32;
+#[cfg(target_arch = "wasm32")]
+use core::arch::wasm32 as wasm;
+#[cfg(target_arch = "wasm64")]
+use core::arch::wasm64 as wasm;
 use core::ptr;
 use Allocator;
 
@@ -16,7 +19,7 @@ impl System {
 unsafe impl Allocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let pages = size / self.page_size();
-        let prev = wasm32::memory_grow(0, pages);
+        let prev = wasm::memory_grow(0, pages);
         if prev == usize::max_value() {
             return (ptr::null_mut(), 0, 0);
         }


### PR DESCRIPTION
Tweak some cfgs and some code to ensure that this crate compiles and
works on wasm64 in the same manner as wasm32