### PR TITLE
xous: indicate a3-a7 are clobbered by ecall

### DIFF
--- a/src/xous.rs
+++ b/src/xous.rs
@@ -29,6 +29,11 @@ mod sys {
                 inlateout("a0") a0,
                 inlateout("a1") a1,
                 inlateout("a2") a2,
+                out("a3") _,
+                out("a4") _,
+                out("a5") _,
+                out("a6") _,
+                out("a7") _,
             )
         };
 


### PR DESCRIPTION
Due to a misunderstanding of the new `asm!()` macro, registers `a3` - `a7` were left out of the invocation. As the Xous OS always writes all 8 argument registers as part of a syscall, this resulted in registers getting clobbered without Rust knowing.

Update the macro invocation to indicate they are clobbered in order to cause llvm to save them prior to the call.