### PR TITLE
Perform some long-needed maintenance here

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install Rust (
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: cargo test
@@ -24,7 +24,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
@@ -33,7 +33,7 @@ jobs:
     name: WebAssembly
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup target add wasm32-unknown-unknown
     - run: cargo build --target wasm32-unknown-unknown
@@ -43,7 +43,32 @@ jobs:
     name: external-platform
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup target add x86_64-fortanix-unknown-sgx
     - run: cargo build --target x86_64-fortanix-unknown-sgx
+
+  fuzz:
+    name: Build Fuzzers
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      run: rustup update nightly && rustup default nightly
+    - run: cargo install cargo-fuzz
+    - run: cargo fuzz build --dev
+
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Miri
+      run: |
+	rustup toolchain install nightly --component miri
+	rustup override set nightly
+	cargo miri setup
+    - name: Test with Miri
+      run: cargo miri test
+      env:
+        MIRIFLAGS: -Zmiri-tree-borrows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,9 +65,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Miri
       run: |
-	rustup toolchain install nightly --component miri
-	rustup override set nightly
-	cargo miri setup
+        rustup toolchain install nightly --component miri
+        rustup override set nightly
+        cargo miri setup
     - name: Test with Miri
       run: cargo miri test
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ documentation = "https://docs.rs/dlmalloc"
 description = """
 A Rust port of the dlmalloc allocator
 """
+edition.workspace = true
+
+[workspace]
+members = ['fuzz']
+
+[workspace.package]
+edition = '2021'
 
 [package.metadata.docs.rs]
 features = ['global']
@@ -27,7 +34,8 @@ core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core
 compiler_builtins = { version = '0.1.0', optional = true }
 
 [dev-dependencies]
-rand = "0.3"
+arbitrary = "1.3.2"
+rand = { version = "0.8", features = ['small_rng'] }
 
 [profile.release]
 debug-assertions = true

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,2 @@
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dlmalloc-fuzz"
+version = "0.0.1"
+publish = false
+edition.workspace = true
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+arbitrary = "1.3.2"
+dlmalloc = { path = '..' }
+libfuzzer-sys = "0.4.7"
+
+[[bin]]
+name = "alloc"
+path = "fuzz_targets/alloc.rs"
+test = false
+bench = false

--- a/fuzz/fuzz_targets/alloc.rs
+++ b/fuzz/fuzz_targets/alloc.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|bytes: &[u8]| {
+    let _ = dlmalloc_fuzz::run(&mut Unstructured::new(bytes));
+});

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,73 @@
+use arbitrary::{Result, Unstructured};
+use dlmalloc::Dlmalloc;
+use std::cmp;
+
+pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
+    let mut a = Dlmalloc::new();
+    let mut ptrs = Vec::new();
+    unsafe {
+        while u.arbitrary()? {
+            let free =
+                ptrs.len() > 0 && ((ptrs.len() < 10_000 && u.ratio(1, 3)?) || u.arbitrary()?);
+            if free {
+                let idx = u.choose_index(ptrs.len())?;
+                let (ptr, size, align) = ptrs.swap_remove(idx);
+                a.free(ptr, size, align);
+                continue;
+            }
+
+            if ptrs.len() > 0 && u.ratio(1, 100)? {
+                let idx = u.choose_index(ptrs.len())?;
+                let (ptr, size, align) = ptrs.swap_remove(idx);
+                let new_size = if u.arbitrary()? {
+                    u.int_in_range(size..=size * 2)?
+                } else if size > 10 {
+                    u.int_in_range(size / 2..=size)?
+                } else {
+                    continue;
+                };
+                let mut tmp = Vec::new();
+                for i in 0..cmp::min(size, new_size) {
+                    tmp.push(*ptr.offset(i as isize));
+                }
+                let ptr = a.realloc(ptr, size, align, new_size);
+                assert!(!ptr.is_null());
+                for (i, byte) in tmp.iter().enumerate() {
+                    assert_eq!(*byte, *ptr.offset(i as isize));
+                }
+                ptrs.push((ptr, new_size, align));
+            }
+
+            let size = if u.arbitrary()? {
+                u.int_in_range(1..=128)?
+            } else {
+                u.int_in_range(1..=128 * 1024)?
+            };
+            let align = if u.ratio(1, 10)? {
+                1 << u.int_in_range(3..=8)?
+            } else {
+                8
+            };
+
+            let zero = u.ratio(1, 50)?;
+            let ptr = if zero {
+                a.calloc(size, align)
+            } else {
+                a.malloc(size, align)
+            };
+            for i in 0..size {
+                if zero {
+                    assert_eq!(*ptr.offset(i as isize), 0);
+                }
+                *ptr.offset(i as isize) = 0xce;
+            }
+            ptrs.push((ptr, size, align));
+        }
+
+        for (ptr, size, align) in ptrs {
+            a.free(ptr, size, align);
+        }
+    }
+
+    Ok(())
+}

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -2,7 +2,7 @@ use arbitrary::{Result, Unstructured};
 use dlmalloc::Dlmalloc;
 use std::cmp;
 
-const MAX_ALLOCATION: usize = 100 << 20; // 100 MB
+const MAX_ALLOCATED: usize = 100 << 20; // 100 MB
 
 pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
     let mut a = Dlmalloc::new();
@@ -10,8 +10,15 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
     let mut allocated = 0;
     unsafe {
         while u.arbitrary()? {
-            let free =
-                ptrs.len() > 0 && ((ptrs.len() < 10_000 && u.ratio(1, 3)?) || u.arbitrary()?);
+            // If there are pointers to free then have a chance of deallocating
+            // a pointer. Try not to deallocate things until there's a "large"
+            // working set but afterwards give it a 50/50 chance of allocating
+            // or deallocating.
+            let free = match ptrs.len() {
+                0 => false,
+                0..=10_000 => u.ratio(1, 3)?,
+                _ => u.arbitrary()?,
+            };
             if free {
                 let idx = u.choose_index(ptrs.len())?;
                 let (ptr, size, align) = ptrs.swap_remove(idx);
@@ -20,9 +27,13 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
                 continue;
             }
 
+            // 1/100 chance of reallocating a pointer to a different size.
             if ptrs.len() > 0 && u.ratio(1, 100)? {
                 let idx = u.choose_index(ptrs.len())?;
                 let (ptr, size, align) = ptrs.swap_remove(idx);
+
+                // Arbitrarily choose whether to make this allocation either
+                // twice as large or half as small.
                 let new_size = if u.arbitrary()? {
                     u.int_in_range(size..=size * 2)?
                 } else if size > 10 {
@@ -30,6 +41,14 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
                 } else {
                     continue;
                 };
+                if allocated + new_size - size > MAX_ALLOCATED {
+                    ptrs.push((ptr, size, align));
+                    continue;
+                }
+                allocated -= size;
+                allocated += new_size;
+
+                // Perform the `realloc` and assert that all bytes were copied.
                 let mut tmp = Vec::new();
                 for i in 0..cmp::min(size, new_size) {
                     tmp.push(*ptr.offset(i as isize));
@@ -42,6 +61,8 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
                 ptrs.push((ptr, new_size, align));
             }
 
+            // Aribtrarily choose a size to allocate as well as an alignment.
+            // Enable small sizes with standard alignment happening a fair bit.
             let size = if u.arbitrary()? {
                 u.int_in_range(1..=128)?
             } else {
@@ -53,11 +74,13 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
                 8
             };
 
-            if size + allocated > MAX_ALLOCATION {
+            if size + allocated > MAX_ALLOCATED {
                 continue;
             }
             allocated += size;
 
+            // Choose arbitrarily between a zero-allocated chunk and a normal
+            // allocated chunk.
             let zero = u.ratio(1, 50)?;
             let ptr = if zero {
                 a.calloc(size, align)
@@ -73,9 +96,12 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
             ptrs.push((ptr, size, align));
         }
 
+        // Deallocate everythign when we're done.
         for (ptr, size, align) in ptrs {
             a.free(ptr, size, align);
         }
+
+        a.destroy();
     }
 
     Ok(())

--- a/src/dlmalloc.rs
+++ b/src/dlmalloc.rs
@@ -7,7 +7,7 @@ use core::cmp;
 use core::mem;
 use core::ptr;
 
-use Allocator;
+use crate::Allocator;
 
 pub struct Dlmalloc<A> {
     smallmap: u32,
@@ -1789,7 +1789,7 @@ impl Segment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use System;
+    use crate::System;
 
     // Prime the allocator with some allocations such that there will be free
     // chunks in the treemap

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -1,5 +1,5 @@
+use crate::Allocator;
 use core::ptr;
-use Allocator;
 
 pub struct System {
     _priv: (),

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,9 +1,8 @@
+use crate::Dlmalloc;
 use core::alloc::{GlobalAlloc, Layout};
 use core::ops::{Deref, DerefMut};
 
-use Dlmalloc;
-
-pub use sys::enable_alloc_after_fork;
+pub use crate::sys::enable_alloc_after_fork;
 
 /// An instance of a "global allocator" backed by `Dlmalloc`
 ///
@@ -38,7 +37,7 @@ static mut DLMALLOC: Dlmalloc = Dlmalloc::new();
 struct Instance;
 
 unsafe fn get() -> Instance {
-    ::sys::acquire_global_lock();
+    crate::sys::acquire_global_lock();
     Instance
 }
 
@@ -57,6 +56,6 @@ impl DerefMut for Instance {
 
 impl Drop for Instance {
     fn drop(&mut self) {
-        ::sys::release_global_lock()
+        crate::sys::release_global_lock()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ impl<A: Allocator> Dlmalloc<A> {
     /// method contracts.
     #[inline]
     pub unsafe fn free(&mut self, ptr: *mut u8, size: usize, align: usize) {
-        drop((size, align));
+        let _ = (size, align);
         self.0.free(ptr)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,4 +176,33 @@ impl<A: Allocator> Dlmalloc<A> {
             res
         }
     }
+
+    /// If possible, gives memory back to the system if there is unused memory
+    /// at the high end of the malloc pool or in unused segments.
+    ///
+    /// You can call this after freeing large blocks of memory to potentially
+    /// reduce the system-level memory requirements of a program. However, it
+    /// cannot guarantee to reduce memory. Under some allocation patterns, some
+    /// large free blocks of memory will be locked between two used chunks, so
+    /// they cannot be given back to the system.
+    ///
+    /// The `pad` argument represents the amount of free trailing space to
+    /// leave untrimmed. If this argument is zero, only the minimum amount of
+    /// memory to maintain internal data structures will be left. Non-zero
+    /// arguments can be supplied to maintain enough trailing space to service
+    /// future expected allocations without having to re-obtain memory from the
+    /// system.
+    ///
+    /// Returns `true` if it actually released any memory, else `false`.
+    pub unsafe fn trim(&mut self, pad: usize) -> bool {
+        self.0.trim(pad)
+    }
+
+    /// Releases all allocations in this allocator back to the system,
+    /// consuming self and preventing further use.
+    ///
+    /// Returns the number of bytes released to the system.
+    pub unsafe fn destroy(self) -> usize {
+        self.0.destroy()
+    }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 
+use crate::Allocator;
 use core::ptr;
-use Allocator;
 
 /// System setting for Linux
 pub struct System {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -21,7 +21,7 @@ unsafe impl Allocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let addr = unsafe {
             libc::mmap(
-                0 as *mut _,
+                ptr::null_mut(),
                 size,
                 libc::PROT_WRITE | libc::PROT_READ,
                 libc::MAP_ANON | libc::MAP_PRIVATE,
@@ -32,18 +32,18 @@ unsafe impl Allocator for System {
         if addr == libc::MAP_FAILED {
             (ptr::null_mut(), 0, 0)
         } else {
-            (addr as *mut u8, size, 0)
+            (addr.cast(), size, 0)
         }
     }
 
     #[cfg(target_os = "linux")]
     fn remap(&self, ptr: *mut u8, oldsize: usize, newsize: usize, can_move: bool) -> *mut u8 {
         let flags = if can_move { libc::MREMAP_MAYMOVE } else { 0 };
-        let ptr = unsafe { libc::mremap(ptr as *mut _, oldsize, newsize, flags) };
+        let ptr = unsafe { libc::mremap(ptr.cast(), oldsize, newsize, flags) };
         if ptr == libc::MAP_FAILED {
             ptr::null_mut()
         } else {
-            ptr as *mut u8
+            ptr.cast()
         }
     }
 
@@ -55,21 +55,21 @@ unsafe impl Allocator for System {
     #[cfg(target_os = "linux")]
     fn free_part(&self, ptr: *mut u8, oldsize: usize, newsize: usize) -> bool {
         unsafe {
-            let rc = libc::mremap(ptr as *mut _, oldsize, newsize, 0);
+            let rc = libc::mremap(ptr.cast(), oldsize, newsize, 0);
             if rc != libc::MAP_FAILED {
                 return true;
             }
-            libc::munmap(ptr.offset(newsize as isize) as *mut _, oldsize - newsize) == 0
+            libc::munmap(ptr.add(newsize).cast(), oldsize - newsize) == 0
         }
     }
 
     #[cfg(target_os = "macos")]
     fn free_part(&self, ptr: *mut u8, oldsize: usize, newsize: usize) -> bool {
-        unsafe { libc::munmap(ptr.offset(newsize as isize) as *mut _, oldsize - newsize) == 0 }
+        unsafe { libc::munmap(ptr.add(newsize).cast(), oldsize - newsize) == 0 }
     }
 
     fn free(&self, ptr: *mut u8, size: usize) -> bool {
-        unsafe { libc::munmap(ptr as *mut _, size) == 0 }
+        unsafe { libc::munmap(ptr.cast(), size) == 0 }
     }
 
     fn can_release_part(&self, _flags: u32) -> bool {
@@ -87,12 +87,12 @@ unsafe impl Allocator for System {
 
 #[cfg(feature = "global")]
 pub fn acquire_global_lock() {
-    unsafe { assert_eq!(libc::pthread_mutex_lock(&mut LOCK), 0) }
+    unsafe { assert_eq!(libc::pthread_mutex_lock(ptr::addr_of_mut!(LOCK)), 0) }
 }
 
 #[cfg(feature = "global")]
 pub fn release_global_lock() {
-    unsafe { assert_eq!(libc::pthread_mutex_unlock(&mut LOCK), 0) }
+    unsafe { assert_eq!(libc::pthread_mutex_unlock(ptr::addr_of_mut!(LOCK)), 0) }
 }
 
 #[cfg(feature = "global")]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,9 +1,9 @@
+use crate::Allocator;
 #[cfg(target_arch = "wasm32")]
 use core::arch::wasm32 as wasm;
 #[cfg(target_arch = "wasm64")]
 use core::arch::wasm64 as wasm;
 use core::ptr;
-use Allocator;
 
 /// System setting for Wasm
 pub struct System {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -59,14 +59,17 @@ unsafe impl Allocator for System {
 #[cfg(feature = "global")]
 pub fn acquire_global_lock() {
     // single threaded, no need!
+    assert!(!cfg!(target_feature = "atomics"));
 }
 
 #[cfg(feature = "global")]
 pub fn release_global_lock() {
     // single threaded, no need!
+    assert!(!cfg!(target_feature = "atomics"));
 }
 
 #[cfg(feature = "global")]
 pub unsafe fn enable_alloc_after_fork() {
     // single threaded, no need!
+    assert!(!cfg!(target_feature = "atomics"));
 }

--- a/src/xous.rs
+++ b/src/xous.rs
@@ -1,5 +1,5 @@
+use crate::Allocator;
 use core::ptr;
-use Allocator;
 
 pub struct System {
     _priv: (),

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -27,7 +27,8 @@ mod fuzz;
 fn stress() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut buf = vec![0; 4096];
-    for _ in 0..2049 {
+    let iters = if cfg!(miri) { 10 } else { 2000 };
+    for _ in 0..iters {
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
         let _ = fuzz::run(&mut u);

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -27,7 +27,7 @@ mod fuzz;
 fn stress() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut buf = vec![0; 4096];
-    let iters = if cfg!(miri) { 10 } else { 2000 };
+    let iters = if cfg!(miri) { 5 } else { 2000 };
     for _ in 0..iters {
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,9 +1,6 @@
-extern crate dlmalloc;
-extern crate rand;
-
+use arbitrary::Unstructured;
 use dlmalloc::Dlmalloc;
-use rand::Rng;
-use std::cmp;
+use rand::{rngs::SmallRng, RngCore, SeedableRng};
 
 #[test]
 fn smoke() {
@@ -23,69 +20,16 @@ fn smoke() {
     }
 }
 
+#[path = "../fuzz/src/lib.rs"]
+mod fuzz;
+
 #[test]
 fn stress() {
-    let mut a = Dlmalloc::new();
-    let mut rng = rand::thread_rng();
-    let mut ptrs = Vec::new();
-    let max = if cfg!(test_lots) { 1_000_000 } else { 1_000 };
-    unsafe {
-        for _ in 0..max {
-            let free =
-                ptrs.len() > 0 && ((ptrs.len() < 10_000 && rng.gen_weighted_bool(3)) || rng.gen());
-            if free {
-                let idx = rng.gen_range(0, ptrs.len());
-                let (ptr, size, align) = ptrs.swap_remove(idx);
-                a.free(ptr, size, align);
-                continue;
-            }
-
-            if ptrs.len() > 0 && rng.gen_weighted_bool(100) {
-                let idx = rng.gen_range(0, ptrs.len());
-                let (ptr, size, align) = ptrs.swap_remove(idx);
-                let new_size = if rng.gen() {
-                    rng.gen_range(size, size * 2)
-                } else if size > 10 {
-                    rng.gen_range(size / 2, size)
-                } else {
-                    continue;
-                };
-                let mut tmp = Vec::new();
-                for i in 0..cmp::min(size, new_size) {
-                    tmp.push(*ptr.offset(i as isize));
-                }
-                let ptr = a.realloc(ptr, size, align, new_size);
-                assert!(!ptr.is_null());
-                for (i, byte) in tmp.iter().enumerate() {
-                    assert_eq!(*byte, *ptr.offset(i as isize));
-                }
-                ptrs.push((ptr, new_size, align));
-            }
-
-            let size = if rng.gen() {
-                rng.gen_range(1, 128)
-            } else {
-                rng.gen_range(1, 128 * 1024)
-            };
-            let align = if rng.gen_weighted_bool(10) {
-                1 << rng.gen_range(3, 8)
-            } else {
-                8
-            };
-
-            let zero = rng.gen_weighted_bool(50);
-            let ptr = if zero {
-                a.calloc(size, align)
-            } else {
-                a.malloc(size, align)
-            };
-            for i in 0..size {
-                if zero {
-                    assert_eq!(*ptr.offset(i as isize), 0);
-                }
-                *ptr.offset(i as isize) = 0xce;
-            }
-            ptrs.push((ptr, size, align));
-        }
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut buf = vec![0; 4096];
+    for _ in 0..2049 {
+        rng.fill_bytes(&mut buf);
+        let mut u = Unstructured::new(&buf);
+        let _ = fuzz::run(&mut u);
     }
 }


### PR DESCRIPTION
* Update to the 2021 edition
* Extract a fuzzer
* Add some helper methods required by fuzzing (ported from `dlmalloc.c`)
* Modernize a bit of code by removing `as` casts and using more modern abstractions
* Add MIRI testing in CI (just tree borrows for now haven't gotten stack borrows working yet)