### PR TITLE
Update to windows-sys v0.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ compiler_builtins = { version = '0.1.0', optional = true }
 cfg-if = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.52.0"
+version = ">=0.52.0, <=0.59.*"
 features = [
   "Win32_Foundation",
   "Win32_System_Memory",


### PR DESCRIPTION
This is the first new version since v0.52. Since dlmalloc compiles and passes tests without any changes, I relaxed the version requirement to allow both versions. That should contribute a little to avoiding lockfiles with two windows-sys versions in them. Such duplication is pretty harmless in the case of dlmalloc (since it's rarely if ever built for windows by dependents), but at the very least it still trips up tools like cargo-deny that scan the lockfile.