### PR TITLE
Add an accessor for the `Allocator` that a `Dlmalloc` was constructed with

### DIFF
--- a/src/dlmalloc.rs
+++ b/src/dlmalloc.rs
@@ -130,6 +130,10 @@ impl<A> Dlmalloc<A> {
             system_allocator,
         }
     }
+
+    pub fn allocator(&self) -> &A {
+        &self.system_allocator
+    }
 }
 
 impl<A: Allocator> Dlmalloc<A> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,4 +206,10 @@ impl<A: Allocator> Dlmalloc<A> {
     pub unsafe fn destroy(self) -> usize {
         self.0.destroy()
     }
+
+    /// Get a reference the underlying [`Allocator`] that this `Dlmalloc` was
+    /// constructed with.
+    pub fn allocator(&self) -> &A {
+        self.0.allocator()
+    }
 }


### PR DESCRIPTION
r? @alexcrichton 