### PR TITLE
For WASM, `alloc` rounds UP when dividing size by page size.

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -18,7 +18,7 @@ impl System {
 
 unsafe impl Allocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
-        let pages = size / self.page_size();
+        let pages = size.div_ceil(self.page_size());
         let prev = wasm::memory_grow(0, pages);
         if prev == usize::max_value() {
             return (ptr::null_mut(), 0, 0);


### PR DESCRIPTION
This way, `alloc` does not allocate too little.

This was discussed and agreed to in [issue 47].

[issue 47]: https://github.com/alexcrichton/dlmalloc-rs/issues/47