### PR TITLE
Add `Dlmalloc::allocator_mut()` method

### DIFF
--- a/src/dlmalloc.rs
+++ b/src/dlmalloc.rs
@@ -134,6 +134,10 @@ impl<A> Dlmalloc<A> {
     pub fn allocator(&self) -> &A {
         &self.system_allocator
     }
+
+    pub fn allocator_mut(&mut self) -> &mut A {
+        &mut self.system_allocator
+    }
 }
 
 impl<A: Allocator> Dlmalloc<A> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,4 +212,10 @@ impl<A: Allocator> Dlmalloc<A> {
     pub fn allocator(&self) -> &A {
         self.0.allocator()
     }
+
+    /// Get a mutable reference to the underlying [`Allocator`] that this
+    /// `Dlmalloc` was constructed with.
+    pub fn allocator_mut(&mut self) -> &mut A {
+        self.0.allocator_mut()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<A: Allocator> Dlmalloc<A> {
         self.0.destroy()
     }
 
-    /// Get a reference the underlying [`Allocator`] that this `Dlmalloc` was
+    /// Get a reference to the underlying [`Allocator`] that this `Dlmalloc` was
     /// constructed with.
     pub fn allocator(&self) -> &A {
         self.0.allocator()


### PR DESCRIPTION
To complement `Dlmalloc::allocator()` added in #46.