### PR TITLE
Don't allocate the final addresses on wasm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
           - os: ubuntu-latest
             rust: stable
             target: wasm32-wasip1
+          - os: ubuntu-latest
+            rust: stable
+            target: i686-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v4
     - run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           - os: ubuntu-latest
             rust: stable
             target: i686-unknown-linux-gnu
+            gcc_target: i686-linux-gnu
     steps:
     - uses: actions/checkout@v4
     - run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
@@ -42,6 +43,17 @@ jobs:
       if: matrix.target == 'wasm32-wasip1'
     - run: echo CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime >> $GITHUB_ENV
       if: matrix.target == 'wasm32-wasip1'
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+
+        sudo apt-get update
+        sudo apt-get install -y gcc-${{ matrix.gcc_target }}
+
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc_target }}-gcc >> $GITHUB_ENV
+      if: matrix.gcc_target != ''
 
     - run: cargo test
     - run: cargo test --features debug

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -20,7 +20,6 @@ unsafe impl Allocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let pages = size.div_ceil(self.page_size());
         let prev = wasm::memory_grow(0, pages);
-        let prev_page = prev * self.page_size();
 
         // If the allocation failed, meaning `prev` is -1 or
         // `usize::max_value()`, then return null.
@@ -28,6 +27,7 @@ unsafe impl Allocator for System {
             return (ptr::null_mut(), 0, 0);
         }
 
+        let prev_page = prev * self.page_size();
         let base_ptr = prev_page as *mut u8;
         let size = pages * self.page_size();
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -20,14 +20,29 @@ unsafe impl Allocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let pages = size.div_ceil(self.page_size());
         let prev = wasm::memory_grow(0, pages);
+        let prev_page = prev * self.page_size();
+
+        // If the allocation failed, meaning `prev` is -1 or
+        // `usize::max_value()`, then return null.
         if prev == usize::max_value() {
             return (ptr::null_mut(), 0, 0);
         }
-        (
-            (prev * self.page_size()) as *mut u8,
-            pages * self.page_size(),
-            0,
-        )
+
+        let base_ptr = prev_page as *mut u8;
+        let size = pages * self.page_size();
+
+        // Additionally check to see if we just allocated the final bit of the
+        // address space. In such a situation it's not valid in Rust for a
+        // pointer to actually wrap around to from the top of the address space
+        // to 0, so it's not valid to allocate the entire region. Fake the last
+        // few bytes as being un-allocated meaning that the actual size of this
+        // allocation won't be page aligned, which should be handled by
+        // dlmalloc.
+        if prev_page.wrapping_add(size) == 0 {
+            return (base_ptr, size - 16, 0);
+        }
+
+        (base_ptr, size, 0)
     }
 
     fn remap(&self, _ptr: *mut u8, _oldsize: usize, _newsize: usize, _can_move: bool) -> *mut u8 {

--- a/tests/eat_memory.rs
+++ b/tests/eat_memory.rs
@@ -1,0 +1,28 @@
+// This test requires the `global` feature, and then also require a 32-bit
+// platform as otherwise exhausting the address space on 64-bit platforms is
+// unreasonable.
+#![cfg(all(feature = "global", target_pointer_width = "32"))]
+
+use std::mem;
+
+#[global_allocator]
+static A: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+fn get_vec_allocated_near_end_of_address_space() -> Vec<u8> {
+    // Reserve a 1.5 GiB outer vector, to OOM faster
+    let mut test_vector: Vec<Vec<u8>> = Vec::with_capacity(2usize.pow(27));
+
+    // Allocate 1KiB vectors until we run out of memory
+    loop {
+        let mut inner_vector = vec![];
+        if inner_vector.try_reserve_exact(1024).is_err() {
+            return mem::take(test_vector.last_mut().unwrap());
+        };
+        test_vector.push(inner_vector);
+    }
+}
+
+#[test]
+fn eat_memory() {
+    get_vec_allocated_near_end_of_address_space();
+}


### PR DESCRIPTION
This is intended at being one fix to rust-lang/rust#144199. It's not valid in Rust for an allocation to include the final byte of the address space, so when the final wasm page is allocated it cannot be entirely in use. This fakes the last 16 bytes as un-allocate-able and this is sufficient for resolving rust-lang/rust#144199.