### PR TITLE
Update to windows-sys 0.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core
 cfg-if = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = ">=0.52.0, <=0.59.*"
+version = ">=0.52.0, <=0.60.*"
 features = [
   "Win32_Foundation",
   "Win32_System_Memory",


### PR DESCRIPTION
Same procedure as last time (#44): simply relax the version bound since no changes in dlmalloc are needed.