### PR TITLE
Add layout-free allocation methods for the C ABI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,8 +219,60 @@ impl<A: Allocator> Dlmalloc<A> {
         self.0.allocator_mut()
     }
 
-    /// Provides access to the underlying C-style allocator
-    pub fn get_inner_mut(&mut self) -> &mut dlmalloc::Dlmalloc<A> {
-        &mut self.0
+    /// Allocates `size` bytes with the allocator's natural alignment.
+    ///
+    /// Intended for wrapping the C `malloc(size_t)` ABI, which does not carry
+    /// alignment information. Returned memory is aligned to at least
+    /// `2 * size_of::<usize>()` (matching what the C `dlmalloc` implementation
+    /// guarantees for `malloc`). If a larger alignment is required, use
+    /// [`Dlmalloc::malloc`] instead.
+    ///
+    /// Returns a null pointer if allocation fails.
+    ///
+    /// # Safety
+    ///
+    /// Pointers returned by this method must be released with
+    /// [`Dlmalloc::free_no_layout`] or resized with
+    /// [`Dlmalloc::realloc_no_layout`]. They must not be passed to
+    /// [`Dlmalloc::free`] or [`Dlmalloc::realloc`], which assume layout
+    /// information that this method does not record.
+    #[inline]
+    pub unsafe fn malloc_no_layout(&mut self, size: usize) -> *mut u8 {
+        self.0.malloc(size)
+    }
+
+    /// Reallocates `ptr` to `new_size` bytes without layout information.
+    ///
+    /// Intended for wrapping the C `realloc(void *, size_t)` ABI. `ptr` must
+    /// have been obtained from [`Dlmalloc::malloc_no_layout`] or a previous
+    /// call to this method.
+    ///
+    /// Returns a null pointer if the memory couldn't be reallocated, in which
+    /// case `ptr` is still valid. Returns a valid pointer and frees `ptr` on
+    /// success.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must originate from a layout-free allocation made by this same
+    /// allocator. The resulting pointer carries the same constraints as one
+    /// returned by [`Dlmalloc::malloc_no_layout`].
+    #[inline]
+    pub unsafe fn realloc_no_layout(&mut self, ptr: *mut u8, new_size: usize) -> *mut u8 {
+        self.0.realloc(ptr, new_size)
+    }
+
+    /// Frees `ptr` without layout information.
+    ///
+    /// Intended for wrapping the C `free(void *)` ABI. `ptr` must have been
+    /// obtained from [`Dlmalloc::malloc_no_layout`] or
+    /// [`Dlmalloc::realloc_no_layout`].
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must originate from a layout-free allocation made by this same
+    /// allocator and must not have been freed already.
+    #[inline]
+    pub unsafe fn free_no_layout(&mut self, ptr: *mut u8) {
+        self.0.free(ptr)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,17 +110,18 @@ impl<A: Allocator> Dlmalloc<A> {
     /// Allocates `size` bytes with `align` align.
     ///
     /// Returns a null pointer if allocation fails. Returns a valid pointer
-    /// otherwise.
+    /// otherwise. A `size` of `0` is also accepted, behaving as
+    /// [`Dlmalloc::c_malloc`].
     ///
-    /// Safety and contracts are largely governed by the `GlobalAlloc::alloc`
-    /// method contracts.
+    /// See [`Dlmalloc::c_malloc`] / [`Dlmalloc::c_memalign`] for the
+    /// layout-free, C-shaped counterparts; pointers from either API may
+    /// be freed or reallocated through the other.
+    ///
+    /// Safety and contracts are otherwise largely governed by the
+    /// `GlobalAlloc::alloc` method contracts.
     #[inline]
     pub unsafe fn malloc(&mut self, size: usize, align: usize) -> *mut u8 {
-        if align <= self.0.malloc_alignment() {
-            self.0.malloc(size)
-        } else {
-            self.0.memalign(align, size)
-        }
+        self.c_memalign(align, size)
     }
 
     /// Same as `malloc`, except if the allocation succeeds it's guaranteed to
@@ -137,24 +138,54 @@ impl<A: Allocator> Dlmalloc<A> {
     /// Deallocates a `ptr` with `size` and `align` as the previous request used
     /// to allocate it.
     ///
-    /// Safety and contracts are largely governed by the `GlobalAlloc::dealloc`
-    /// method contracts.
+    /// See [`Dlmalloc::c_free`] for the layout-free, C-shaped counterpart;
+    /// pointers from either API may be freed by this method.
+    ///
+    /// # Safety
+    ///
+    /// `size` and `align` must match the values originally supplied when
+    /// `ptr` was allocated. For pointers obtained from
+    /// [`Dlmalloc::c_malloc`] or [`Dlmalloc::c_realloc`], use
+    /// `2 * size_of::<usize>()` for `align`; for [`Dlmalloc::c_memalign`],
+    /// pass the originally-requested `align`. Passing the wrong `size` or
+    /// `align` violates this method's safety contract.
+    ///
+    /// Safety and contracts are otherwise largely governed by the
+    /// `GlobalAlloc::dealloc` method contracts.
     #[inline]
     pub unsafe fn free(&mut self, ptr: *mut u8, size: usize, align: usize) {
         let _ = align;
         self.0.validate_size(ptr, size);
-        self.0.free(ptr)
+        self.c_free(ptr)
     }
 
     /// Reallocates `ptr`, a previous allocation with `old_size` and
-    /// `old_align`, to have `new_size` and the same alignment as before.
+    /// `old_align`, to have `new_size` bytes.
+    ///
+    /// If `old_align` exceeds the natural malloc alignment
+    /// (`2 * size_of::<usize>()`), this preserves the original alignment.
+    /// Otherwise the returned pointer is only guaranteed to be naturally
+    /// aligned, matching [`Dlmalloc::c_realloc`].
     ///
     /// Returns a null pointer if the memory couldn't be reallocated, but `ptr`
     /// is still valid. Returns a valid pointer and frees `ptr` if the request
     /// is satisfied.
     ///
-    /// Safety and contracts are largely governed by the `GlobalAlloc::realloc`
-    /// method contracts.
+    /// See [`Dlmalloc::c_realloc`] for the layout-free, C-shaped
+    /// counterpart.
+    ///
+    /// # Safety
+    ///
+    /// `old_size` and `old_align` must match the values originally supplied
+    /// when `ptr` was allocated. For pointers obtained from
+    /// [`Dlmalloc::c_malloc`] or [`Dlmalloc::c_realloc`], use
+    /// `2 * size_of::<usize>()` for `old_align`; for
+    /// [`Dlmalloc::c_memalign`], pass the originally-requested `align`.
+    /// Passing the wrong `old_size` or `old_align` violates this method's
+    /// safety contract.
+    ///
+    /// Safety and contracts are otherwise largely governed by the
+    /// `GlobalAlloc::realloc` method contracts.
     #[inline]
     pub unsafe fn realloc(
         &mut self,
@@ -166,7 +197,7 @@ impl<A: Allocator> Dlmalloc<A> {
         self.0.validate_size(ptr, old_size);
 
         if old_align <= self.0.malloc_alignment() {
-            self.0.realloc(ptr, new_size)
+            self.c_realloc(ptr, new_size)
         } else {
             let res = self.malloc(new_size, old_align);
             if !res.is_null() {
@@ -219,91 +250,103 @@ impl<A: Allocator> Dlmalloc<A> {
         self.0.allocator_mut()
     }
 
-    /// Allocates `size` bytes with the allocator's natural alignment.
+    /// Allocates `size` bytes at the allocator's natural alignment of
+    /// `2 * size_of::<usize>()`.
     ///
-    /// Intended for wrapping the C `malloc(size_t)` ABI, which does not carry
-    /// alignment information. Returned memory is aligned to at least
-    /// `2 * size_of::<usize>()` (matching what the C `dlmalloc` implementation
-    /// guarantees for `malloc`). If a larger alignment is required, use
-    /// [`Dlmalloc::memalign_no_layout`] instead.
+    /// Layout-free counterpart of [`Dlmalloc::malloc`] for wrapping the C
+    /// `malloc(size_t)` ABI. Any `size` is accepted, including `0`; the
+    /// returned pointer (if non-null) may be freed or resized through the
+    /// deallocation/reallocation methods. Returns a null pointer if
+    /// allocation fails.
     ///
-    /// Returns a null pointer if allocation fails.
+    /// # Compatibility
+    ///
+    /// The `c_*` methods and the layout-carrying methods are two API shapes
+    /// over the same allocator: a pointer obtained from any allocation
+    /// method may be freed or reallocated by any deallocation/reallocation
+    /// method on the same allocator. When crossing from `c_*` to the
+    /// layout-carrying API, supply the original `size` and the alignment
+    /// the allocation was made with — `2 * size_of::<usize>()` for
+    /// `c_malloc`, the original `align` for [`Dlmalloc::c_memalign`].
+    /// Note that reallocating through [`Dlmalloc::c_realloc`] does not
+    /// preserve over-alignment; see its docs.
     ///
     /// # Safety
     ///
-    /// Pointers returned by this method must be released with
-    /// [`Dlmalloc::free_no_layout`] or resized with
-    /// [`Dlmalloc::realloc_no_layout`]. They must not be passed to
-    /// [`Dlmalloc::free`] or [`Dlmalloc::realloc`], which assume layout
-    /// information that this method does not record.
+    /// `c_malloc` has no caller preconditions on `size`. The returned
+    /// pointer, if non-null, is uninitialized memory aligned to
+    /// `2 * size_of::<usize>()` and must eventually be released via one of
+    /// the deallocation methods on the same allocator instance.
     #[inline]
-    pub unsafe fn malloc_no_layout(&mut self, size: usize) -> *mut u8 {
+    pub unsafe fn c_malloc(&mut self, size: usize) -> *mut u8 {
         self.0.malloc(size)
     }
 
     /// Allocates `size` bytes aligned to at least `align` bytes.
     ///
-    /// Intended for wrapping the C `memalign` / `posix_memalign` ABIs. If
-    /// `align` is less than or equal to the allocator's natural alignment
-    /// (currently `2 * size_of::<usize>()`) this falls back to a regular
-    /// allocation; otherwise the result is aligned to `align`.
+    /// Layout-free counterpart for wrapping the C `memalign` /
+    /// `posix_memalign` ABIs. When `align` does not exceed the natural
+    /// malloc alignment (`2 * size_of::<usize>()`) this is equivalent to
+    /// [`Dlmalloc::c_malloc`]. Returns a null pointer if allocation fails.
     ///
-    /// Returns a null pointer if allocation fails.
+    /// See [`Dlmalloc::c_malloc`] for compatibility with the
+    /// layout-carrying API.
     ///
     /// # Safety
     ///
-    /// `align` must be a power of two. Pointers returned by this method
-    /// carry the same constraints as those returned by
-    /// [`Dlmalloc::malloc_no_layout`]: they must be released with
-    /// [`Dlmalloc::free_no_layout`] or resized with
-    /// [`Dlmalloc::realloc_no_layout`], and must not be passed to
-    /// [`Dlmalloc::free`] or [`Dlmalloc::realloc`].
+    /// `align` must be a power of two. The caller's obligations on the
+    /// returned pointer match those of [`Dlmalloc::c_malloc`].
     #[inline]
-    pub unsafe fn memalign_no_layout(&mut self, align: usize, size: usize) -> *mut u8 {
+    pub unsafe fn c_memalign(&mut self, align: usize, size: usize) -> *mut u8 {
         if align <= self.0.malloc_alignment() {
-            self.0.malloc(size)
+            self.c_malloc(size)
         } else {
             self.0.memalign(align, size)
         }
     }
 
-    /// Reallocates `ptr` to `new_size` bytes without layout information.
+    /// Reallocates `ptr` to `new_size` bytes.
     ///
-    /// Intended for wrapping the C `realloc(void *, size_t)` ABI. If `ptr` is
-    /// null this behaves like [`Dlmalloc::malloc_no_layout`]. Otherwise `ptr`
-    /// must have been obtained from [`Dlmalloc::malloc_no_layout`],
-    /// [`Dlmalloc::memalign_no_layout`], or a previous call to this method.
+    /// Layout-free counterpart for wrapping the C `realloc(void *, size_t)`
+    /// ABI. A null `ptr` behaves like [`Dlmalloc::c_malloc`]; otherwise
+    /// `ptr` may come from any allocation method on this allocator
+    /// instance, regardless of the alignment it was allocated with.
     ///
-    /// Returns a null pointer if the memory couldn't be reallocated, in which
-    /// case `ptr` is still valid. Returns a valid pointer and frees `ptr` on
-    /// success.
+    /// The returned pointer is only guaranteed to be aligned to the
+    /// natural malloc alignment (`2 * size_of::<usize>()`), even when
+    /// `ptr` was originally over-aligned via [`Dlmalloc::c_memalign`] or
+    /// [`Dlmalloc::malloc`]. Use [`Dlmalloc::realloc`] when the original
+    /// alignment must be preserved.
+    ///
+    /// Returns a null pointer if the memory couldn't be reallocated, in
+    /// which case `ptr` remains valid. Returns a non-null pointer and
+    /// frees `ptr` on success.
     ///
     /// # Safety
     ///
-    /// If non-null, `ptr` must originate from a layout-free allocation made
-    /// by this same allocator. The resulting pointer carries the same
-    /// constraints as one returned by [`Dlmalloc::malloc_no_layout`].
+    /// If non-null, `ptr` must come from this allocator instance and must
+    /// not have been freed already. The caller's obligations on the
+    /// returned pointer match those of [`Dlmalloc::c_malloc`].
     #[inline]
-    pub unsafe fn realloc_no_layout(&mut self, ptr: *mut u8, new_size: usize) -> *mut u8 {
+    pub unsafe fn c_realloc(&mut self, ptr: *mut u8, new_size: usize) -> *mut u8 {
         if ptr.is_null() {
-            return self.0.malloc(new_size);
+            return self.c_malloc(new_size);
         }
         self.0.realloc(ptr, new_size)
     }
 
-    /// Frees `ptr` without layout information.
+    /// Frees `ptr`.
     ///
-    /// Intended for wrapping the C `free(void *)` ABI. A null `ptr` is a
-    /// no-op. Otherwise `ptr` must have been obtained from
-    /// [`Dlmalloc::malloc_no_layout`], [`Dlmalloc::memalign_no_layout`], or
-    /// [`Dlmalloc::realloc_no_layout`].
+    /// Layout-free counterpart for wrapping the C `free(void *)` ABI. A
+    /// null `ptr` is a no-op; otherwise `ptr` must come from any
+    /// allocation method on this allocator instance.
     ///
     /// # Safety
     ///
-    /// If non-null, `ptr` must originate from a layout-free allocation made
-    /// by this same allocator and must not have been freed already.
+    /// If non-null, `ptr` must come from this allocator and must not have
+    /// been freed already.
     #[inline]
-    pub unsafe fn free_no_layout(&mut self, ptr: *mut u8) {
+    pub unsafe fn c_free(&mut self, ptr: *mut u8) {
         if ptr.is_null() {
             return;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ impl<A: Allocator> Dlmalloc<A> {
     /// alignment information. Returned memory is aligned to at least
     /// `2 * size_of::<usize>()` (matching what the C `dlmalloc` implementation
     /// guarantees for `malloc`). If a larger alignment is required, use
-    /// [`Dlmalloc::malloc`] instead.
+    /// [`Dlmalloc::memalign_no_layout`] instead.
     ///
     /// Returns a null pointer if allocation fails.
     ///
@@ -241,11 +241,38 @@ impl<A: Allocator> Dlmalloc<A> {
         self.0.malloc(size)
     }
 
+    /// Allocates `size` bytes aligned to at least `align` bytes.
+    ///
+    /// Intended for wrapping the C `memalign` / `posix_memalign` ABIs. If
+    /// `align` is less than or equal to the allocator's natural alignment
+    /// (currently `2 * size_of::<usize>()`) this falls back to a regular
+    /// allocation; otherwise the result is aligned to `align`.
+    ///
+    /// Returns a null pointer if allocation fails.
+    ///
+    /// # Safety
+    ///
+    /// `align` must be a power of two. Pointers returned by this method
+    /// carry the same constraints as those returned by
+    /// [`Dlmalloc::malloc_no_layout`]: they must be released with
+    /// [`Dlmalloc::free_no_layout`] or resized with
+    /// [`Dlmalloc::realloc_no_layout`], and must not be passed to
+    /// [`Dlmalloc::free`] or [`Dlmalloc::realloc`].
+    #[inline]
+    pub unsafe fn memalign_no_layout(&mut self, align: usize, size: usize) -> *mut u8 {
+        if align <= self.0.malloc_alignment() {
+            self.0.malloc(size)
+        } else {
+            self.0.memalign(align, size)
+        }
+    }
+
     /// Reallocates `ptr` to `new_size` bytes without layout information.
     ///
-    /// Intended for wrapping the C `realloc(void *, size_t)` ABI. `ptr` must
-    /// have been obtained from [`Dlmalloc::malloc_no_layout`] or a previous
-    /// call to this method.
+    /// Intended for wrapping the C `realloc(void *, size_t)` ABI. If `ptr` is
+    /// null this behaves like [`Dlmalloc::malloc_no_layout`]. Otherwise `ptr`
+    /// must have been obtained from [`Dlmalloc::malloc_no_layout`],
+    /// [`Dlmalloc::memalign_no_layout`], or a previous call to this method.
     ///
     /// Returns a null pointer if the memory couldn't be reallocated, in which
     /// case `ptr` is still valid. Returns a valid pointer and frees `ptr` on
@@ -253,26 +280,33 @@ impl<A: Allocator> Dlmalloc<A> {
     ///
     /// # Safety
     ///
-    /// `ptr` must originate from a layout-free allocation made by this same
-    /// allocator. The resulting pointer carries the same constraints as one
-    /// returned by [`Dlmalloc::malloc_no_layout`].
+    /// If non-null, `ptr` must originate from a layout-free allocation made
+    /// by this same allocator. The resulting pointer carries the same
+    /// constraints as one returned by [`Dlmalloc::malloc_no_layout`].
     #[inline]
     pub unsafe fn realloc_no_layout(&mut self, ptr: *mut u8, new_size: usize) -> *mut u8 {
+        if ptr.is_null() {
+            return self.0.malloc(new_size);
+        }
         self.0.realloc(ptr, new_size)
     }
 
     /// Frees `ptr` without layout information.
     ///
-    /// Intended for wrapping the C `free(void *)` ABI. `ptr` must have been
-    /// obtained from [`Dlmalloc::malloc_no_layout`] or
+    /// Intended for wrapping the C `free(void *)` ABI. A null `ptr` is a
+    /// no-op. Otherwise `ptr` must have been obtained from
+    /// [`Dlmalloc::malloc_no_layout`], [`Dlmalloc::memalign_no_layout`], or
     /// [`Dlmalloc::realloc_no_layout`].
     ///
     /// # Safety
     ///
-    /// `ptr` must originate from a layout-free allocation made by this same
-    /// allocator and must not have been freed already.
+    /// If non-null, `ptr` must originate from a layout-free allocation made
+    /// by this same allocator and must not have been freed already.
     #[inline]
     pub unsafe fn free_no_layout(&mut self, ptr: *mut u8) {
+        if ptr.is_null() {
+            return;
+        }
         self.0.free(ptr)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,4 +218,9 @@ impl<A: Allocator> Dlmalloc<A> {
     pub fn allocator_mut(&mut self) -> &mut A {
         self.0.allocator_mut()
     }
+
+    /// Provides access to the underlying C-style allocator
+    pub fn get_inner_mut(&mut self) -> &mut dlmalloc::Dlmalloc<A> {
+        &mut self.0
+    }
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -21,16 +21,16 @@ fn smoke() {
 }
 
 #[test]
-fn no_layout_round_trip() {
+fn c_round_trip() {
     let mut a = Dlmalloc::new();
     unsafe {
-        let ptr = a.malloc_no_layout(32);
+        let ptr = a.c_malloc(32);
         assert!(!ptr.is_null());
         ptr.write_bytes(0xab, 32);
         assert_eq!(*ptr, 0xab);
         assert_eq!(*ptr.add(31), 0xab);
 
-        let grown = a.realloc_no_layout(ptr, 128);
+        let grown = a.c_realloc(ptr, 128);
         assert!(!grown.is_null());
         for i in 0..32 {
             assert_eq!(*grown.add(i), 0xab);
@@ -38,38 +38,38 @@ fn no_layout_round_trip() {
         grown.add(32).write_bytes(0xcd, 96);
         assert_eq!(*grown.add(127), 0xcd);
 
-        let shrunk = a.realloc_no_layout(grown, 16);
+        let shrunk = a.c_realloc(grown, 16);
         assert!(!shrunk.is_null());
         for i in 0..16 {
             assert_eq!(*shrunk.add(i), 0xab);
         }
 
-        a.free_no_layout(shrunk);
+        a.c_free(shrunk);
     }
 }
 
 #[test]
-fn no_layout_null_handling() {
+fn c_null_handling() {
     let mut a = Dlmalloc::new();
     unsafe {
-        a.free_no_layout(core::ptr::null_mut());
+        a.c_free(core::ptr::null_mut());
 
-        let ptr = a.realloc_no_layout(core::ptr::null_mut(), 64);
+        let ptr = a.c_realloc(core::ptr::null_mut(), 64);
         assert!(!ptr.is_null());
         ptr.write_bytes(0x5a, 64);
         assert_eq!(*ptr, 0x5a);
         assert_eq!(*ptr.add(63), 0x5a);
-        a.free_no_layout(ptr);
+        a.c_free(ptr);
     }
 }
 
 #[test]
-fn memalign_no_layout_round_trip() {
+fn c_memalign_round_trip() {
     let mut a = Dlmalloc::new();
     unsafe {
         for &align in &[1usize, 2, 8, 16, 32, 64, 256, 4096] {
-            let ptr = a.memalign_no_layout(align, 96);
-            assert!(!ptr.is_null(), "memalign_no_layout({align}, 96) failed");
+            let ptr = a.c_memalign(align, 96);
+            assert!(!ptr.is_null(), "c_memalign({align}, 96) failed");
             assert_eq!(
                 (ptr as usize) & (align - 1),
                 0,
@@ -79,14 +79,87 @@ fn memalign_no_layout_round_trip() {
             assert_eq!(*ptr, 0x77);
             assert_eq!(*ptr.add(95), 0x77);
 
-            let grown = a.realloc_no_layout(ptr, 256);
+            let grown = a.c_realloc(ptr, 256);
             assert!(!grown.is_null());
             for i in 0..96 {
                 assert_eq!(*grown.add(i), 0x77);
             }
 
-            a.free_no_layout(grown);
+            a.c_free(grown);
         }
+    }
+}
+
+#[test]
+fn mixed_api_round_trip() {
+    let mut a = Dlmalloc::new();
+    let natural = core::mem::size_of::<usize>() * 2;
+    unsafe {
+        // c_malloc -> layout-carrying free
+        let ptr = a.c_malloc(64);
+        assert!(!ptr.is_null());
+        ptr.write_bytes(0x11, 64);
+        a.free(ptr, 64, natural);
+
+        // layout-carrying malloc -> c_free
+        let ptr = a.malloc(64, natural);
+        assert!(!ptr.is_null());
+        ptr.write_bytes(0x22, 64);
+        a.c_free(ptr);
+
+        // c_malloc -> layout-carrying realloc -> c_free
+        let ptr = a.c_malloc(48);
+        assert!(!ptr.is_null());
+        ptr.write_bytes(0x33, 48);
+        let grown = a.realloc(ptr, 48, natural, 192);
+        assert!(!grown.is_null());
+        for i in 0..48 {
+            assert_eq!(*grown.add(i), 0x33);
+        }
+        a.c_free(grown);
+
+        // layout-carrying malloc -> c_realloc -> layout-carrying free
+        let ptr = a.malloc(48, natural);
+        assert!(!ptr.is_null());
+        ptr.write_bytes(0x44, 48);
+        let grown = a.c_realloc(ptr, 192);
+        assert!(!grown.is_null());
+        for i in 0..48 {
+            assert_eq!(*grown.add(i), 0x44);
+        }
+        a.free(grown, 192, natural);
+
+        // over-aligned c_memalign -> c_free
+        let ptr = a.c_memalign(4096, 96);
+        assert!(!ptr.is_null());
+        assert_eq!((ptr as usize) & (4096 - 1), 0);
+        ptr.write_bytes(0x55, 96);
+        a.c_free(ptr);
+
+        // over-aligned c_memalign -> layout-carrying free
+        let ptr = a.c_memalign(4096, 96);
+        assert!(!ptr.is_null());
+        assert_eq!((ptr as usize) & (4096 - 1), 0);
+        ptr.write_bytes(0x66, 96);
+        a.free(ptr, 96, 4096);
+
+        // over-aligned c_memalign -> layout-carrying realloc preserves
+        // alignment, then layout-carrying free
+        let ptr = a.c_memalign(4096, 96);
+        assert!(!ptr.is_null());
+        assert_eq!((ptr as usize) & (4096 - 1), 0);
+        ptr.write_bytes(0x77, 96);
+        let grown = a.realloc(ptr, 96, 4096, 256);
+        assert!(!grown.is_null());
+        assert_eq!(
+            (grown as usize) & (4096 - 1),
+            0,
+            "layout-carrying realloc must preserve over-alignment"
+        );
+        for i in 0..96 {
+            assert_eq!(*grown.add(i), 0x77);
+        }
+        a.free(grown, 256, 4096);
     }
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -38,7 +38,55 @@ fn no_layout_round_trip() {
         grown.add(32).write_bytes(0xcd, 96);
         assert_eq!(*grown.add(127), 0xcd);
 
-        a.free_no_layout(grown);
+        let shrunk = a.realloc_no_layout(grown, 16);
+        assert!(!shrunk.is_null());
+        for i in 0..16 {
+            assert_eq!(*shrunk.add(i), 0xab);
+        }
+
+        a.free_no_layout(shrunk);
+    }
+}
+
+#[test]
+fn no_layout_null_handling() {
+    let mut a = Dlmalloc::new();
+    unsafe {
+        a.free_no_layout(core::ptr::null_mut());
+
+        let ptr = a.realloc_no_layout(core::ptr::null_mut(), 64);
+        assert!(!ptr.is_null());
+        ptr.write_bytes(0x5a, 64);
+        assert_eq!(*ptr, 0x5a);
+        assert_eq!(*ptr.add(63), 0x5a);
+        a.free_no_layout(ptr);
+    }
+}
+
+#[test]
+fn memalign_no_layout_round_trip() {
+    let mut a = Dlmalloc::new();
+    unsafe {
+        for &align in &[1usize, 2, 8, 16, 32, 64, 256, 4096] {
+            let ptr = a.memalign_no_layout(align, 96);
+            assert!(!ptr.is_null(), "memalign_no_layout({align}, 96) failed");
+            assert_eq!(
+                (ptr as usize) & (align - 1),
+                0,
+                "ptr {ptr:p} not aligned to {align}"
+            );
+            ptr.write_bytes(0x77, 96);
+            assert_eq!(*ptr, 0x77);
+            assert_eq!(*ptr.add(95), 0x77);
+
+            let grown = a.realloc_no_layout(ptr, 256);
+            assert!(!grown.is_null());
+            for i in 0..96 {
+                assert_eq!(*grown.add(i), 0x77);
+            }
+
+            a.free_no_layout(grown);
+        }
     }
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -20,6 +20,28 @@ fn smoke() {
     }
 }
 
+#[test]
+fn no_layout_round_trip() {
+    let mut a = Dlmalloc::new();
+    unsafe {
+        let ptr = a.malloc_no_layout(32);
+        assert!(!ptr.is_null());
+        ptr.write_bytes(0xab, 32);
+        assert_eq!(*ptr, 0xab);
+        assert_eq!(*ptr.add(31), 0xab);
+
+        let grown = a.realloc_no_layout(ptr, 128);
+        assert!(!grown.is_null());
+        for i in 0..32 {
+            assert_eq!(*grown.add(i), 0xab);
+        }
+        grown.add(32).write_bytes(0xcd, 96);
+        assert_eq!(*grown.add(127), 0xcd);
+
+        a.free_no_layout(grown);
+    }
+}
+
 #[path = "../fuzz/src/lib.rs"]
 mod fuzz;
 


### PR DESCRIPTION
The `GlobalAlloc`-style methods on `Dlmalloc` require a `Layout` on
dealloc/realloc, but the C ABI (`malloc`, `free`, `realloc`, `memalign`)
doesn't carry one. This adds four `*_no_layout` methods so FFI wrappers can
forward C calls directly without smuggling layout through a side channel:

- `malloc_no_layout(size)`: natural-alignment allocation
- `memalign_no_layout(align, size)`: for `memalign` / `posix_memalign`
- `realloc_no_layout(ptr, new_size)`: null `ptr` behaves like malloc
- `free_no_layout(ptr)`: null `ptr` is a no-op

Pointers from these methods must round-trip through the `*_no_layout` family,
not the layout-carrying `free`/`realloc`. Includes round-trip, null-handling,
and alignment tests.
